### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@asyncapi/jmeter-template",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lagoni/jmeter-template",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Generate JMeter performance test plans for your application using the AsyncAPI generator.",
 	"keywords": [
 		"asyncapi",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.1.0](https://github.com/jonaslagoni/JMeter-template/releases/tag/v0.1.0)